### PR TITLE
bloodlight_rev2/Kconfig.defconfig: Add vendor and product id

### DIFF
--- a/boards/arm/bloodlight_rev2/Kconfig.defconfig
+++ b/boards/arm/bloodlight_rev2/Kconfig.defconfig
@@ -13,3 +13,16 @@ config SPI_STM32_INTERRUPT
 	depends on SPI
 
 endif
+
+config USB_DEVICE_VID
+	hex "USB Vendor ID"
+	default 0x0483
+	depends on USB
+    help
+      USB device vendor ID. MUST be configured by vendor.
+config USB_DEVICE_PID
+	hex "USB Product ID"
+	default 0x5740
+	depends on USB
+    help
+      USB device product ID. MUST be configured by vendor.


### PR DESCRIPTION
This values were taken  from [bloodlight-firmware/src/usb.c](https://github.com/CodethinkLabs/bloodlight-firmware/blob/65f4308d6d197dc288723b762341b2c780d54633/firmware/src/usb.c#L62)

Signed-off-by: Iker Perez del Palomar Sustatxa <iker.perez@codethink.co.uk>